### PR TITLE
chore: do not upload the demo to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
   "peerDependencies": {
     "vite": ">= 2.0.0-beta.5"
   },
+  "files": [
+    "src",
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/onebay/vite-plugin-imp.git"


### PR DESCRIPTION
Hey, i'm using this plugin to import `element-plus`, i notice the unpacked size is too large in npm