### PR TITLE
fix(resolver): compatible with vant@3.5.0

### DIFF
--- a/src/resolvers/vant.ts
+++ b/src/resolvers/vant.ts
@@ -3,5 +3,5 @@ import { LibResolver } from '../types'
 export const VantResolver: LibResolver = {
   libName: 'vant',
   replaceOldImport: false,
-  style: (name) => `vant/es/${name}/style/index.js`
+  style: (name) => `vant/es/${name}/style`
 }


### PR DESCRIPTION
vant@3.5.0 has adjusted the file extension of ESModules from .js to .mjs, This resulted in the following error:

```
[vite-plugin-imp] vant/es/toast/style/index.js is not found!
```

https://youzan.github.io/vant/#/en-US/changelog

Like [vite-plugin-style-import code for vant resolver](https://github.com/vbenjs/vite-plugin-style-import/blob/460234fa9accd820a8fd927325f998111e5c44b2/packages/core/src/resolve/vant.ts#L8), the suffix can be ignored.

Although it can work normally, there still see the warning, It seems that this part of the inspection is incorrect, I try to append `.mjs` suffix to vant resolver like `vant/es/${name}/style/index.mjs`, then the warning is gone, but this will lead to the incompatibility of the vant before version 3.5.0, so is there a better way to check? @psaren 

https://github.com/onebay/vite-plugin-imp/blob/8112cc1d5d9c13d20ed2df105cc8e0416ba4c5ec/src/shared.ts#L99-L118