### PR TITLE
fix: require style paths in context of cwd

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -4,11 +4,14 @@ import chalk from 'chalk'
 import { paramCase } from 'param-case'
 import { ResolvedConfig } from 'vite'
 import { ImpConfig, ImportMaps } from './types'
+import { Module as module } from 'module'
 import * as path from 'path'
 import * as fs from 'fs'
 
 // for mjs
 const generate = typeof Generate === 'function' ? Generate : (Generate as any).default;
+
+const createRequire = module.createRequire || module.createRequireFromPath
 
 function getType(obj: any) {
   return Object.prototype.toString.call(obj).slice(8, -1);
@@ -106,7 +109,7 @@ const stylePathNotFoundHandler = (stylePath: string, ignoreStylePathNotFound: bo
     let stylePathExists = true
     try {
       // require is used to detect the existence of style files
-      require(stylePath)
+      createRequire(process.cwd() + path.sep).resolve(stylePath)
     } catch (error: any) {
       stylePathExists = error?.code !== 'MODULE_NOT_FOUND'
     }


### PR DESCRIPTION
Fixes issues where style paths could not be resolved because the dependency was a dependency of the project using Vite and not of vite-plugin-imp:

```
[vite-plugin-imp] ant-design-vue/es/space/style/css.js is not found!
[vite-plugin-imp] If you think this is a bug, feel free to open an issue on https://github.com/onebay/vite-plugin-imp/issues
```

In this example, vite-plugin-imp does not define ant-design-vue as a dependency, but the project that uses vite-plugin-imp does. Therefore, the `require` call needs to be created in context of the correct directory rather than from the context of vite-plugin-imp.

One common case happens in the context of Yarn PnP, since Yarn enforces strict dependency checks.